### PR TITLE
Makefile fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ $(APP_OBJS): $(INCLUDE)/tk1_mem.h app/app_proto.h app/blink.h
 .PHONY: clean
 clean:
 	$(RM) -f app/app.bin app/app.elf app/main.o
-	$(RM) -f runpattern cmd/app.bin
+	$(RM) -f $(CLIENTAPP) cmd/app.bin
 
 # Uses ../.clang-format
 FMTFILES=app/*.[ch]

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ $(APP_OBJS): $(INCLUDE)/tk1_mem.h app/app_proto.h app/blink.h
 
 .PHONY: clean
 clean:
-	$(RM) -f app/app.bin app/app.elf app/main.o
+	$(RM) -f app/app.bin app/app.elf app/*.o
 	$(RM) -f $(CLIENTAPP) cmd/app.bin
 
 # Uses ../.clang-format


### PR DESCRIPTION
- now clean all `*.o` files compiled from device app
- use `CLIENTAPP` variable instead of hardcoded `runpattern` executable name
  - making it easier to change the executable name, when using this repo as a template